### PR TITLE
Adding summary data to all of the articles

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,9 +1,91 @@
-# Readme
+## Files:
 
+├── billing.md
+├── buildpacks-custom.md
+├── buildpacks-pinning.md
+├── buildpacks.md
+├── cli-database-backup.md
+├── cli-database-export.md
+├── cli-database-import.md
+├── cli-stratum.md
+├── cloud-storage.md
+├── code-deployment.md
+├── codeship-deployments.md
+├── contact.md
+├── contract-process.md
+├── create-user-account.md
+├── database-general.md
+├── environment-defining.md
+├── environment-metrics.md
+├── environment-variables-manage.md
+├── environment-variables.md
+├── guides
+│   ├── application-logging.md
+│   ├── elastic-search-querying.md
+│   ├── local-testing.md
+│   ├── node-mongo.md
+│   ├── php-mysql.md
+│   ├── python-postgres.md
+│   ├── rails-postgres.md
+│   ├── self-service-SSL.md
+│   └── vpn-client-setup.md
+├── ha-application.md
+├── ha-mongo.md
+├── ha-postgres.md
+├── ha-redis.md
+├── images
+│   ├── account_email.png
+│   ├── account_register.png
+│   ├── auth_popup.png
+│   ├── buildpack_release_frontpage.png
+│   ├── buildpack_release_github.png
+│   ├── dashboard_env_variables.png
+│   ├── dashboard_user_delete.png
+│   ├── dashboard_view_details.png
+│   ├── kibana_logging_home.png
+│   ├── metrics_cpu.png
+│   ├── metrics_duration.png
+│   ├── metrics_memory.png
+│   ├── metrics_network.png
+│   ├── organization_dropdown.png
+│   ├── organization_invite.png
+│   ├── organization_invite_pending.png
+│   ├── sensu_clients.png
+│   ├── sensu_frontpage.png
+│   ├── sensu_interface.png
+│   ├── sensu_service.png
+│   ├── view_details.png
+│   ├── vpn_name.png
+│   ├── vpn_psk.png
+│   ├── vpn_userpass.png
+│   └── vpn_userpass_highlights.png
+├── initial-setup.md
+├── logging-access.md
+├── logging-custom-dashboard.md
+├── monitoring-customization.md
+├── monitoring.md
+├── organization-access-controls.md
+├── organization-addremove-users.md
+├── organizations.md
+├── s3-bucket-access.md
+├── s3-bucket-policies.md
+├── scaling.md
+├── scheduled-tasks.md
+├── setting-up-dns.md
+├── ssh-keys.md
+├── ssl-self-signed.md
+├── ssl-verify.md
+├── supported-addons.md
+├── supported-databases.md
+├── supported-languages-frameworks.md
+├── vpn-stratum.md
+├── worker-deploy.md
+└── worker-general.md
 
-## Onboarding List
+## Onboarding List:
 
-- [Contract Process](/contract-process.md/)
+- [Initial Setup Guide](/initial-setup.md/)
+- [NA: Contract Process](/contract-process.md/)
 - [Organization Concepts](/organizations.md/)
 - [Organization Access Controls](/organization-access-controls.md/)
 - [Contact Catalyze](/contact.md/)

--- a/billing.md
+++ b/billing.md
@@ -1,6 +1,7 @@
 ---
-title: Stratum Billing
+title: Catalyze Resources - Stratum Billing
 category: getting-started
+summary: What forms of payment do you accept?
 ---
 
 # Stratum Billing

--- a/buildpacks-custom.md
+++ b/buildpacks-custom.md
@@ -1,6 +1,7 @@
 ---
-title: Custom Buildpacks
+title: Catalyze Resources - Custom Buildpacks
 category: buildpack
+summary: How can I modify the Stratum buildpack process?
 ---
 
 # How can I modify the Stratum buildpack process?

--- a/buildpacks-pinning.md
+++ b/buildpacks-pinning.md
@@ -1,6 +1,7 @@
 ---
-title: Using a Specific Buildpack Version
+title: Catalyze Resources - Using a Specific Buildpack Version
 category: buildpack
+summary: While Stratum can detect and apply a buildpack automatically, Catalyze recommends that Stratum users pin their buildpacks to a specific version.
 ---
 
 # Using a Specific Buildpack Version

--- a/buildpacks.md
+++ b/buildpacks.md
@@ -1,11 +1,10 @@
 ---
-title: Buildpack General
+title: Catalyze Resources - Buildpack General
 category: buildpack
+summary: Learn about buildpacks.
 ---
 
 # What is a buildpack?
-
-## What is a buildpack?
 
 A buildpack is a framework for constructing your application's software stack. It is extremely flexible and is intended to operate as an agent to your environment. The buildpack agent will attempt to understand your stack and install any dependencies required by it.
 

--- a/cli-database-backup.md
+++ b/cli-database-backup.md
@@ -1,10 +1,10 @@
 ---
 title: Catalyze Resources - Database Backups
 category: database
-summary: How do I preform a database backup?
+summary: How do I perform a database backup?
 ---
 
-# How do I preform a database backup?
+# How do I perform a database backup?
 
 ## Backup
 

--- a/cli-database-backup.md
+++ b/cli-database-backup.md
@@ -1,9 +1,13 @@
 ---
-title: Database Backups
+title: Catalyze Resources - Database Backups
 category: database
+summary: How do I preform a database backup?
 ---
 
+# How do I preform a database backup?
+
 ## Backup
+
 The CLI backup command is there for you to create snapshots of your data, perhaps, in preparation for a software upgrade or data migration. A nightly backup of your database is also automated. All of these backups can be viewed with the CLI backup commands. Backups are encrypted and stored in cloud storage and retained for 7 days. The following examples will show you how to create and list database backups performed via the CLI.
 
 ### Create a Backup

--- a/cli-database-export.md
+++ b/cli-database-export.md
@@ -1,6 +1,7 @@
 ---
-title: Database Export
+title: Catalyze Resources - Database Export
 category: database
+summary: Learn how to export database data from the Stratum CLI.
 ---
 
 ## Export

--- a/cli-database-import.md
+++ b/cli-database-import.md
@@ -1,8 +1,8 @@
 ---
-title: Database Import
+title: Catalyze Resources - Database Import
 category: database
+summary: Learn how to import your data into Stratum.
 ---
-
 
 ## Import
 All of the import functionality in the CLI starts with preparing a file to import. Here is a table outlining the file types appropriate for each supported database on the Catalyze platform.

--- a/cli-stratum.md
+++ b/cli-stratum.md
@@ -1,6 +1,7 @@
 ---
-title: The Stratum CLI
+title: Catalyze Resources - The Stratum CLI
 category: getting-started
+summary: Download the Catalyze CLI.
 ---
 
 # The Stratum CLI

--- a/cloud-storage.md
+++ b/cloud-storage.md
@@ -1,6 +1,7 @@
 ---
-title: Cloud Storage
+title: Catalyze Resources - Cloud Storage
 category: storage
+summary: Learn about using Cloud Storage with your Catalyze Stratum account.
 ---
 
 # Stratum Cloud Storage

--- a/code-deployment.md
+++ b/code-deployment.md
@@ -1,6 +1,7 @@
 ---
-title: Deploying Your Application to Catalyze
+title: Catalyze Resources - Deploying Your Application to Catalyze
 category: application
+summary: How do I deploy to my Catalyze environment?
 ---
 
 # How do I deploy to my Catalyze environment?

--- a/codeship-deployments.md
+++ b/codeship-deployments.md
@@ -1,6 +1,7 @@
 ---
-title: Setting Up Codeship to Deploy to Catalyze
+title: Catalyze Resources - Setting Up Codeship to Deploy to Catalyze
 category: manage
+summary: How do I setup Codeship to deploy to Catalyze?
 ---
 
 # How do I setup Codeship to deploy to Catalyze?

--- a/contact.md
+++ b/contact.md
@@ -1,5 +1,6 @@
 ---
-title: Catalyze Contact Information
+title: Catalyze Resources - Catalyze Contact Information
+summary: Need to contact Catalyze? We're always here to help!
 ---
 
 # Catalyze Contact information

--- a/contract-process.md
+++ b/contract-process.md
@@ -1,5 +1,6 @@
 ---
-title: Catalyze Contracting
+title: Catalyze Resources - Catalyze Contracting
+summary: How does the Catalyze contracting process work?
 ---
 
 # How does the Catalyze contracting process work?

--- a/create-user-account.md
+++ b/create-user-account.md
@@ -1,6 +1,7 @@
 ---
-title: Creating a User Account
+title: Catalyze Resources - Creating a User Account
 category: getting-started
+summary: How do I get access to a Stratum organization or environment?
 ---
 
 # How do I get access to a Stratum organization or environment?

--- a/database-general.md
+++ b/database-general.md
@@ -1,7 +1,7 @@
 ---
 title: Catalyze Resources - Database General Information
 category: database
-summary: Learn about databses on Stratum.
+summary: Learn about databases on Stratum.
 ---
 
 ## What versions of the [supported databases](/stratum/articles/supported-databases/) does Catalyze use?

--- a/database-general.md
+++ b/database-general.md
@@ -1,6 +1,7 @@
 ---
-title: Database General Information
+title: Catalyze Resources - Database General Information
 category: database
+summary: Learn about databses on Stratum.
 ---
 
 ## What versions of the [supported databases](/stratum/articles/supported-databases/) does Catalyze use?

--- a/environment-defining.md
+++ b/environment-defining.md
@@ -1,6 +1,7 @@
 ---
-title: Stratum Environment Definition
+title: Catalyze Resources - Stratum Environment Definition
 category: getting-started
+summary: What does a Stratum environment look like?
 ---
 
 # What does a Stratum environment look like?

--- a/environment-metrics.md
+++ b/environment-metrics.md
@@ -1,6 +1,7 @@
 ---
-title: Stratum Environment Metrics
+title: Catalyze Resources - Stratum Environment Metrics
 category: manage
+summary: See what metrics are available in Stratum.
 ---
 
 # Stratum Environment Metrics

--- a/environment-variables-manage.md
+++ b/environment-variables-manage.md
@@ -1,6 +1,7 @@
 ---
-title: Managing Environment Variables
+title: Catalyze Resources - Managing Environment Variables
 category: manage
+summary: Learn how to manage your environment variables on Stratum.
 ---
 
 # Managing Environment Variables

--- a/environment-variables.md
+++ b/environment-variables.md
@@ -1,6 +1,7 @@
 ---
-title: Stratum Environment Variables
+title: Catalyze Resources - Stratum Environment Variables
 category: manage
+summary: Learn about environment variables in Stratum.
 ---
 
 # Stratum Environment Variables
@@ -36,4 +37,4 @@ The service's environment variables are located here:
 
 ## Setting Your Own Variables
 
-[Link to Managing Environment Variables]
+To set your own environment variables checkout our environment variable management guide located [here](/stratum/articles/environment-variables-manage/).

--- a/ha-application.md
+++ b/ha-application.md
@@ -1,6 +1,7 @@
 ---
-title: HA applications
+title: Catalyze Resources - HA applications
 category: application
+summary: How does Stratum manage HA applications?
 ---
 
 # How does Stratum manage HA applications?

--- a/ha-mongo.md
+++ b/ha-mongo.md
@@ -1,6 +1,7 @@
 ---
-title: HA Mongo
+title: Catalyze Resources - HA Mongo
 category: database
+summary: How does Stratum manage HA Mongo?
 ---
 
 # How does Stratum manage HA Mongo?

--- a/ha-postgres.md
+++ b/ha-postgres.md
@@ -1,6 +1,7 @@
 ---
-title: HA Postgres
+title: Catalyze Resources - HA Postgres
 category: database
+Summary: How does Stratum manage HA Postgres?
 ---
 
 # How does Stratum manage HA Postgres?

--- a/ha-redis.md
+++ b/ha-redis.md
@@ -1,6 +1,7 @@
 ---
-title: HA Redis
+title: Catalyze Resources - HA Redis
 category: cache
+summary: How does Stratum manage HA Redis?
 ---
 
 # How does Stratum manage HA Redis?

--- a/initial-setup.md
+++ b/initial-setup.md
@@ -1,6 +1,7 @@
 ---
-title: Stratum Initial Setup
+title: Catalyze Resources - Stratum Initial Setup
 category: getting-started
+Summary: Brand new to Stratum? Start here!
 ---
 
 ## Introduction

--- a/logging-access.md
+++ b/logging-access.md
@@ -1,6 +1,7 @@
 ---
-title: Stratum Environment Logging
+title: Catalyze Resources - Stratum Environment Logging
 category: logging
+summary: Learn how logging works in Stratum.
 ---
 
 # Stratum Environment Logging

--- a/logging-custom-dashboard.md
+++ b/logging-custom-dashboard.md
@@ -1,6 +1,7 @@
 ---
-title: Customize Kibana
+title: Catalyze Resources - Customize Kibana
 category: logging
+summary: How can I customize Kibana?
 ---
 
 # How can I customize Kibana?

--- a/memached.md
+++ b/memached.md
@@ -1,3 +1,0 @@
----
-title: Memcached
----

--- a/monitoring-customization.md
+++ b/monitoring-customization.md
@@ -1,6 +1,7 @@
 ---
-title: Customize Monitoring
+title: Catalyze Resources - Customize Monitoring
 category: monitoring
+summary: Can I customize Stratum monitoring?
 ---
 
 # Can I customize Stratum monitoring?

--- a/monitoring.md
+++ b/monitoring.md
@@ -1,6 +1,7 @@
 ---
-title: Stratum Environment Monitoring
+title: Catalyze Resources - Stratum Environment Monitoring
 category: monitoring
+summary: Learn how to use Catalyze's monitoring service.
 ---
 
 # Stratum Environment Monitoring

--- a/organization-access-controls.md
+++ b/organization-access-controls.md
@@ -1,6 +1,7 @@
 ---
-title: Organization Concepts
+title: Catalyze Resources - Organization Concepts
 category: organization
+summary: Learn how to manage your organization on Catalyze.
 ---
 
 # Stratum Organization Concepts
@@ -11,7 +12,7 @@ After completing the paperwork for your first environment, Catalyze will create 
 
 Organizations have three levels of roles:
 
-- ***Member*** (Available early March 2016)
+- ***Member***
   - Belong to the organization but must be given access to specific environments
   - Cannot manage other users
 - ***Admin***

--- a/organization-addremove-users.md
+++ b/organization-addremove-users.md
@@ -1,6 +1,7 @@
 ---
-title: Managing Users
+title: Catalyze Resources - Managing Users
 category: organization
+Summary: How can I add or remove users with my organization?
 ---
 
 # How can I add or remove users with my organization?

--- a/organizations.md
+++ b/organizations.md
@@ -1,6 +1,7 @@
 ---
-title: Organizations
+title: Catalyze Resources - Organizations
 category: organization
+summary: What is a Stratum Organization?
 ---
 
 # What is a Stratum Organization?

--- a/rabbitmq.md
+++ b/rabbitmq.md
@@ -1,3 +1,0 @@
----
-title: RabbitMQ
----

--- a/s3-bucket-access.md
+++ b/s3-bucket-access.md
@@ -1,6 +1,7 @@
 ---
 title: S3 Bucket Access
 category: storage
+summary: How can I access my Catalyze S3 Bucket?
 ---
 
 # How can I access my Catalyze S3 Bucket?

--- a/s3-bucket-access.md
+++ b/s3-bucket-access.md
@@ -1,5 +1,5 @@
 ---
-title: S3 Bucket Access
+title: Catalyze Resources - S3 Bucket Access
 category: storage
 summary: How can I access my Catalyze S3 Bucket?
 ---

--- a/s3-bucket-policies.md
+++ b/s3-bucket-policies.md
@@ -1,6 +1,7 @@
 ---
-title: S3 Bucket Policies
+title: Catalyze Resources - S3 Bucket Policies
 category: storage
+summary: How are Catalyze S3 Buckets managed?
 ---
 
 # How are Catalyze S3 Buckets managed?

--- a/scaling.md
+++ b/scaling.md
@@ -1,6 +1,7 @@
 ---
-title: Scaling With Stratum
+title: Catalyze Resources - Scaling With Stratum
 category: manage
+summary: How can I scale with Catalyze and Stratum?
 ---
 
 # How can I scale with Catalyze and Stratum?

--- a/scheduled-tasks.md
+++ b/scheduled-tasks.md
@@ -1,6 +1,7 @@
 ---
-title: Scheduled Tasks in Stratum
+title: Catalyze Resources - Scheduled Tasks in Stratum
 category: manage
+summary: Learn about scheduled tasks in Stratum.
 ---
 
 # Scheduled Tasks in Stratum

--- a/setting-up-dns.md
+++ b/setting-up-dns.md
@@ -1,6 +1,7 @@
 ---
-title: Setting Up DNS
+title: Catalyze Resources - Setting Up DNS
 category: ssl
+summary: How do I setup DNS to point to my Catalyze environment?
 ---
 
 # How do I setup DNS to point to my Catalyze environment?

--- a/ssh-keys.md
+++ b/ssh-keys.md
@@ -1,6 +1,7 @@
 ---
-title: Stratum SSH Keys
+title: Catalyze Resources - Stratum SSH Keys
 category: manage
+summary: Learn how to manage your SSH keys in Stratum.
 ---
 
 # Stratum SSH Keys

--- a/ssl-self-signed.md
+++ b/ssl-self-signed.md
@@ -1,6 +1,7 @@
 ---
-title: Stratum Self-Signed SSL Certs
+title: Catalyze Resources - Stratum Self-Signed SSL Certs
 category: ssl
+summary: Learn about self-signed SSL certificates on Stratum.
 ---
 
 # Self-Signed vs CA-Signed SSL Certs

--- a/ssl-verify.md
+++ b/ssl-verify.md
@@ -1,6 +1,7 @@
 ---
-title: SSL Certificate Verification
+title: Catalyze Resources - SSL Certificate Verification
 category: ssl
+summary: Learn about SSL certificate verification on Stratum.
 ---
 
 # SSL Certificate Verification

--- a/supported-addons.md
+++ b/supported-addons.md
@@ -1,6 +1,7 @@
 ---
-title: Supported Utilities and Add-ons
+title: Catalyze Resources - Supported Utilities and Add-ons
 category: getting-started
+summary: Learn about supported utilities and add-ons for your Stratum environment.
 ---
 
 # Supported Utilities and Add-ons

--- a/supported-databases.md
+++ b/supported-databases.md
@@ -1,6 +1,7 @@
 ---
-title: Stratum Supported Databases
+title: Catalyze Resources - Stratum Supported Databases
 category: database
+summary: Learn about the supported databases you can use on Stratum.
 ---
 
 # Stratum Supported Databases

--- a/supported-languages-frameworks.md
+++ b/supported-languages-frameworks.md
@@ -1,6 +1,7 @@
 ---
-title: Stratum Supported Languages and Frameworks
+title: Catalyze Resources - Stratum Supported Languages and Frameworks
 category: application
+summary: Learn about the support programming languages and frameworks on Catalyze.
 ---
 
 # Stratum Supported Languages and Frameworks

--- a/vpn-stratum.md
+++ b/vpn-stratum.md
@@ -1,6 +1,7 @@
 ---
-title: VPN Access
+title: Catalyze Resources - VPN Access
 category: vpn
+summary: Can I access my Stratum environment via VPN?
 ---
 
 # Can I access my Stratum environment via VPN?

--- a/worker-deploy.md
+++ b/worker-deploy.md
@@ -1,6 +1,7 @@
 ---
-title: Worker Deploy
+title: Catalyze Resources - Worker Deploy
 category: worker
+summary: How do I deploy a worker container?
 ---
 
 # How do I deploy a worker container?

--- a/worker-general.md
+++ b/worker-general.md
@@ -1,6 +1,7 @@
 ---
-title: Background Processing and Workers in Stratum
+title: Catalyze Resources - Background Processing and Workers in Stratum
 category: worker
+summary: Learn about background processing and workers in Stratum.
 ---
 
 # Background Processing and Workers in Stratum


### PR DESCRIPTION
- [x] Added summaries for each article

_Reasoning:_
If the article's intro H1 had a question I used that as the summary. If the article didn't contain an intro question I wrote a short summary about the article.

**Bonus**
I removed Memcached and RabbitMQ articles since they were both empty. The contracting process article is also empty, but I'm hoping we can get that filled out before closing this PR.