### PR TITLE
Changing log path in the cron.sh script

### DIFF
--- a/scheduled-tasks.md
+++ b/scheduled-tasks.md
@@ -30,7 +30,7 @@ If adding a scheduling framework isn't an option, then `cron` may work to period
 
 ```
 #!/bin/sh -e
-LOGFILE=/var/log/cron.log
+LOGFILE=/app/cron.log
 
 crontab my-crontab
 


### PR DESCRIPTION
When troubleshooting zd ticket 3699 and 3403 I found that the randomly…generated user that is used to run the application process does not have write permission to the /var/log directory and is not able to make the log file.